### PR TITLE
Fix deprecated io_control::post usage

### DIFF
--- a/asio2exec.hpp
+++ b/asio2exec.hpp
@@ -256,7 +256,7 @@ private:
                     }
                 }
                 try{
-                    self._ctx->post(__sched_task_t{
+                    __io::post(*self._ctx,__sched_task_t{
                         .self{&self},
                         .allocator{&self._buf}
                     });


### PR DESCRIPTION
In boost 1.87 the io_context::post method was removed as it was deprecated. An explicit asio::post has to be used.